### PR TITLE
Changed sourcePath of the AssetBundle

### DIFF
--- a/DildenFeedbackAsset.php
+++ b/DildenFeedbackAsset.php
@@ -8,7 +8,7 @@ class DildenFeedbackAsset extends AssetBundle {
 
 	public function init()
     {
-        $this->sourcePath = '@app/components/yii2feedbackwidget/assets/';
+        $this->sourcePath = '@vendor/dilden/yii2-feedback-widget/assets/';
         $this->css = [ 
 		    'feedback.min.css'
 		]; 


### PR DESCRIPTION
As I installed the widget, I had to create a directory: yii/frontend/components/yii2feedbackwidget/assets/
And I had to copy all the files from yii/vendor/dilden/yii2-feedback-widget/assets/ to the directory.
After this change it is not necessary.
