### PR TITLE
Typo: Changed the name of ivoviz/feedback variable

### DIFF
--- a/DildenFeedback.php
+++ b/DildenFeedback.php
@@ -72,7 +72,7 @@ class DildenFeedback extends Widget
 					shadowBlur: ".$this->shadowBlur.",
 					lineJoin: '".$this->lineJoin."',
 					lineWidth: ".$this->lineWidth.",
-					html2CanvasURL: '". $this->html2CanvasURL."',
+					html2canvasURL: '". $this->html2CanvasURL."',
 					onClose: ".$this->onClose.",
 					screenshotStroke: ".$this->screenshotStroke.",
 					highlightElement: ". $this->highlightElement .",


### PR DESCRIPTION
I changed the name of html2CanvasURL to html2canvasURL, because Ivoviz/feedback use html2canvasURL, see: https://github.com/ivoviz/feedback/blob/master/stable/2.0/feedback.js

It solves the problem with the error message:
GET https://localhost/yii/frontend/web/html2canvas.js?_=1452683194473 404 (Not Found)
