### PR TITLE
Added the full path of the class Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Setting up your controller to handle the AJAX response is simple enough. Simply 
 ```php
 namespace app\controllers;
 
+use yii\web\Response;
+
 class PinneappleController extends Controller
 {
 


### PR DESCRIPTION
Without the full path of the class, there is no response to the Ajax Post request.
